### PR TITLE
Handle fonts in CairoContext

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -10,13 +10,14 @@
 #' @param bold,italic Is text bold/italic?
 #' @param fontname Font name
 #' @param fontsize Font size
+#' @param fontfile Font file
 #' @examples
 #' str_extents(letters)
 #' str_extents("Hello World!", bold = TRUE, italic = FALSE,
 #'   fontname = "sans", fontsize = 12)
 #' @export
-str_extents <- function(x, fontname = "sans", fontsize = 12, bold = FALSE, italic = FALSE) {
-    .Call('gdtools_str_extents', PACKAGE = 'gdtools', x, fontname, fontsize, bold, italic)
+str_extents <- function(x, fontname = "sans", fontsize = 12, bold = FALSE, italic = FALSE, fontfile = "") {
+    .Call('gdtools_str_extents', PACKAGE = 'gdtools', x, fontname, fontsize, bold, italic, fontfile)
 }
 
 #' Get font metrics for a string.
@@ -38,7 +39,7 @@ context_create <- function() {
     .Call('gdtools_context_create', PACKAGE = 'gdtools')
 }
 
-context_set_font <- function(cc, fontname, fontsize, bold, italic, fontfile) {
+context_set_font <- function(cc, fontname, fontsize, bold, italic, fontfile = "") {
     .Call('gdtools_context_set_font', PACKAGE = 'gdtools', cc, fontname, fontsize, bold, italic, fontfile)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -26,8 +26,8 @@ str_extents <- function(x, fontname = "sans", fontsize = 12, bold = FALSE, itali
 #' @examples
 #' str_metrics("Hello World!")
 #' @export
-str_metrics <- function(x, fontname = "sans", fontsize = 12, bold = FALSE, italic = FALSE) {
-    .Call('gdtools_str_metrics', PACKAGE = 'gdtools', x, fontname, fontsize, bold, italic)
+str_metrics <- function(x, fontname = "sans", fontsize = 12, bold = FALSE, italic = FALSE, fontfile = "") {
+    .Call('gdtools_str_metrics', PACKAGE = 'gdtools', x, fontname, fontsize, bold, italic, fontfile)
 }
 
 str_metrics_from_file <- function(x, fontfiles, fontsize = 12, bold = FALSE, italic = FALSE, fallback = "M") {
@@ -38,8 +38,8 @@ context_create <- function() {
     .Call('gdtools_context_create', PACKAGE = 'gdtools')
 }
 
-context_set_font <- function(cc, fontname, fontsize, bold, italic) {
-    .Call('gdtools_context_set_font', PACKAGE = 'gdtools', cc, fontname, fontsize, bold, italic)
+context_set_font <- function(cc, fontname, fontsize, bold, italic, fontfile) {
+    .Call('gdtools_context_set_font', PACKAGE = 'gdtools', cc, fontname, fontsize, bold, italic, fontfile)
 }
 
 context_extents <- function(cc, x) {

--- a/inst/include/gdtools_RcppExports.h
+++ b/inst/include/gdtools_RcppExports.h
@@ -44,17 +44,17 @@ namespace gdtools {
         return Rcpp::as<XPtrCairoContext >(rcpp_result_gen);
     }
 
-    inline bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic) {
-        typedef SEXP(*Ptr_context_set_font)(SEXP,SEXP,SEXP,SEXP,SEXP);
+    inline bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic, std::string fontfile) {
+        typedef SEXP(*Ptr_context_set_font)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_context_set_font p_context_set_font = NULL;
         if (p_context_set_font == NULL) {
-            validateSignature("bool(*context_set_font)(XPtrCairoContext,std::string,double,bool,bool)");
+            validateSignature("bool(*context_set_font)(XPtrCairoContext,std::string,double,bool,bool,std::string)");
             p_context_set_font = (Ptr_context_set_font)R_GetCCallable("gdtools", "gdtools_context_set_font");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_context_set_font(Rcpp::wrap(cc), Rcpp::wrap(fontname), Rcpp::wrap(fontsize), Rcpp::wrap(bold), Rcpp::wrap(italic));
+            rcpp_result_gen = p_context_set_font(Rcpp::wrap(cc), Rcpp::wrap(fontname), Rcpp::wrap(fontsize), Rcpp::wrap(bold), Rcpp::wrap(italic), Rcpp::wrap(fontfile));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/inst/include/gdtools_RcppExports.h
+++ b/inst/include/gdtools_RcppExports.h
@@ -44,7 +44,7 @@ namespace gdtools {
         return Rcpp::as<XPtrCairoContext >(rcpp_result_gen);
     }
 
-    inline bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic, std::string fontfile) {
+    inline bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic, std::string fontfile = "") {
         typedef SEXP(*Ptr_context_set_font)(SEXP,SEXP,SEXP,SEXP,SEXP,SEXP);
         static Ptr_context_set_font p_context_set_font = NULL;
         if (p_context_set_font == NULL) {

--- a/inst/include/gdtools_types.h
+++ b/inst/include/gdtools_types.h
@@ -41,7 +41,8 @@ public:
   ~CairoContext();
 
   void setFont(std::string fontname = "sans", double fontsize = 12,
-    bool bold = false, bool italic = false);
+               bool bold = false, bool italic = false,
+               std::string fontfile = "");
 
   FontMetric getExtents(std::string x);
 };

--- a/man/str_extents.Rd
+++ b/man/str_extents.Rd
@@ -5,7 +5,7 @@
 \title{Compute string extents.}
 \usage{
 str_extents(x, fontname = "sans", fontsize = 12, bold = FALSE,
-  italic = FALSE)
+  italic = FALSE, fontfile = "")
 }
 \arguments{
 \item{x}{Character vector of of strings to measure}
@@ -15,6 +15,8 @@ str_extents(x, fontname = "sans", fontsize = 12, bold = FALSE,
 \item{fontsize}{Font size}
 
 \item{bold, italic}{Is text bold/italic?}
+
+\item{fontfile}{Font file}
 }
 \description{
 Determines the width and height of a bounding box that's big enough

--- a/man/str_metrics.Rd
+++ b/man/str_metrics.Rd
@@ -5,7 +5,7 @@
 \title{Get font metrics for a string.}
 \usage{
 str_metrics(x, fontname = "sans", fontsize = 12, bold = FALSE,
-  italic = FALSE)
+  italic = FALSE, fontfile = "")
 }
 \arguments{
 \item{x}{Character vector of of strings to measure}
@@ -17,6 +17,8 @@ str_metrics(x, fontname = "sans", fontsize = 12, bold = FALSE,
 \item{bold}{Is text bold/italic?}
 
 \item{italic}{Is text bold/italic?}
+
+\item{fontfile}{Font file}
 }
 \value{
 A named numeric vector

--- a/src/CairoContext.cpp
+++ b/src/CairoContext.cpp
@@ -1,38 +1,70 @@
-#include "gdtools_types.h"
+#include <string>
+#include <map>
+#include <algorithm>
 #include <Rcpp.h>
 #include <cairo.h>
 #include <cairo-pdf.h>
-#include <string.h>
+#include <cairo-ft.h>
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include "gdtools_types.h"
 
 using namespace Rcpp;
 
 struct CairoContext::CairoContext_ {
   cairo_surface_t* surface;
   cairo_t* context;
+  bool currently_freetype; // FIXME: needed?
+  FT_Library library;
+  std::vector<FT_Face> ft_fonts;
+  std::map<std::string, cairo_font_face_t*> fonts;
 };
 
 CairoContext::CairoContext() {
   cairo_ = new CairoContext_();
   cairo_->surface = cairo_pdf_surface_create(NULL, 720, 720);
   cairo_->context = cairo_create(cairo_->surface);
+  cairo_->currently_freetype = 0;
+
+  if (FT_Init_FreeType(&(cairo_->library)))
+    stop("FreeType error : unable to initialize FreeType library object.");
 }
 
 CairoContext::~CairoContext() {
   cairo_surface_destroy(cairo_->surface);
   cairo_destroy(cairo_->context);
+
+  std::map<std::string, cairo_font_face_t*>::iterator fonts_it = cairo_->fonts.begin();
+  while (fonts_it != cairo_->fonts.end()) {
+    cairo_font_face_destroy(fonts_it->second);
+    ++fonts_it;
+  }
+  std::for_each(cairo_->ft_fonts.begin(), cairo_->ft_fonts.end(), &FT_Done_Face);
+
   delete cairo_;
 }
 
 void CairoContext::setFont(std::string fontname, double fontsize,
-  bool bold, bool italic) {
-
-  cairo_select_font_face(cairo_->context,
-    fontname.c_str(),
-    italic ? CAIRO_FONT_SLANT_ITALIC : CAIRO_FONT_SLANT_NORMAL,
-    bold ? CAIRO_FONT_WEIGHT_BOLD : CAIRO_FONT_WEIGHT_NORMAL
-  );
-
+                           bool bold, bool italic, std::string fontfile) {
   cairo_set_font_size(cairo_->context, fontsize);
+
+  if (fontfile.size()) {
+    if (cairo_->fonts.find(fontfile) == cairo_->fonts.end()) {
+      cairo_->ft_fonts.push_back(FT_Face());
+      FT_Face* new_face = &(cairo_->ft_fonts[cairo_->ft_fonts.size()]);
+      FT_New_Face(cairo_->library, fontfile.c_str(), 0, new_face);
+      cairo_->fonts[fontfile] = cairo_ft_font_face_create_for_ft_face(*new_face, 0);
+    }
+    cairo_set_font_face(cairo_->context, cairo_->fonts[fontfile]);
+    cairo_->currently_freetype = 1;
+  } else {
+    cairo_select_font_face(cairo_->context,
+      fontname.c_str(),
+      italic ? CAIRO_FONT_SLANT_ITALIC : CAIRO_FONT_SLANT_NORMAL,
+      bold ? CAIRO_FONT_WEIGHT_BOLD : CAIRO_FONT_WEIGHT_NORMAL
+    );
+    cairo_->currently_freetype = 0;
+  }
 }
 
 FontMetric CairoContext::getExtents(std::string x) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -10,8 +10,8 @@
 using namespace Rcpp;
 
 // str_extents
-NumericMatrix str_extents(CharacterVector x, std::string fontname, double fontsize, int bold, int italic);
-RcppExport SEXP gdtools_str_extents(SEXP xSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP) {
+NumericMatrix str_extents(CharacterVector x, std::string fontname, double fontsize, int bold, int italic, std::string fontfile);
+RcppExport SEXP gdtools_str_extents(SEXP xSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP, SEXP fontfileSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -20,7 +20,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type fontsize(fontsizeSEXP);
     Rcpp::traits::input_parameter< int >::type bold(boldSEXP);
     Rcpp::traits::input_parameter< int >::type italic(italicSEXP);
-    rcpp_result_gen = Rcpp::wrap(str_extents(x, fontname, fontsize, bold, italic));
+    Rcpp::traits::input_parameter< std::string >::type fontfile(fontfileSEXP);
+    rcpp_result_gen = Rcpp::wrap(str_extents(x, fontname, fontsize, bold, italic, fontfile));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -25,8 +25,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // str_metrics
-NumericVector str_metrics(CharacterVector x, std::string fontname, double fontsize, int bold, int italic);
-RcppExport SEXP gdtools_str_metrics(SEXP xSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP) {
+NumericVector str_metrics(CharacterVector x, std::string fontname, double fontsize, int bold, int italic, std::string fontfile);
+RcppExport SEXP gdtools_str_metrics(SEXP xSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP, SEXP fontfileSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -35,7 +35,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type fontsize(fontsizeSEXP);
     Rcpp::traits::input_parameter< int >::type bold(boldSEXP);
     Rcpp::traits::input_parameter< int >::type italic(italicSEXP);
-    rcpp_result_gen = Rcpp::wrap(str_metrics(x, fontname, fontsize, bold, italic));
+    Rcpp::traits::input_parameter< std::string >::type fontfile(fontfileSEXP);
+    rcpp_result_gen = Rcpp::wrap(str_metrics(x, fontname, fontsize, bold, italic, fontfile));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -85,8 +86,8 @@ RcppExport SEXP gdtools_context_create() {
     return rcpp_result_gen;
 }
 // context_set_font
-bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic);
-static SEXP gdtools_context_set_font_try(SEXP ccSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP) {
+bool context_set_font(XPtrCairoContext cc, std::string fontname, double fontsize, bool bold, bool italic, std::string fontfile);
+static SEXP gdtools_context_set_font_try(SEXP ccSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP, SEXP fontfileSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< XPtrCairoContext >::type cc(ccSEXP);
@@ -94,15 +95,16 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type fontsize(fontsizeSEXP);
     Rcpp::traits::input_parameter< bool >::type bold(boldSEXP);
     Rcpp::traits::input_parameter< bool >::type italic(italicSEXP);
-    rcpp_result_gen = Rcpp::wrap(context_set_font(cc, fontname, fontsize, bold, italic));
+    Rcpp::traits::input_parameter< std::string >::type fontfile(fontfileSEXP);
+    rcpp_result_gen = Rcpp::wrap(context_set_font(cc, fontname, fontsize, bold, italic, fontfile));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP gdtools_context_set_font(SEXP ccSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP) {
+RcppExport SEXP gdtools_context_set_font(SEXP ccSEXP, SEXP fontnameSEXP, SEXP fontsizeSEXP, SEXP boldSEXP, SEXP italicSEXP, SEXP fontfileSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(gdtools_context_set_font_try(ccSEXP, fontnameSEXP, fontsizeSEXP, boldSEXP, italicSEXP));
+        rcpp_result_gen = PROTECT(gdtools_context_set_font_try(ccSEXP, fontnameSEXP, fontsizeSEXP, boldSEXP, italicSEXP, fontfileSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -571,7 +573,7 @@ static int gdtools_RcppExport_validate(const char* sig) {
     static std::set<std::string> signatures;
     if (signatures.empty()) {
         signatures.insert("XPtrCairoContext(*context_create)()");
-        signatures.insert("bool(*context_set_font)(XPtrCairoContext,std::string,double,bool,bool)");
+        signatures.insert("bool(*context_set_font)(XPtrCairoContext,std::string,double,bool,bool,std::string)");
         signatures.insert("FontMetric(*context_extents)(XPtrCairoContext,std::string)");
         signatures.insert("XPtrFontFileContext(*fontfile_context_create)(CharacterVector)");
         signatures.insert("bool(*fontfile_context_set_font)(XPtrFontFileContext,double,bool,bool,std::string)");

--- a/src/font_metrics.cpp
+++ b/src/font_metrics.cpp
@@ -54,10 +54,10 @@ NumericMatrix str_extents(CharacterVector x, std::string fontname = "sans",
 // [[Rcpp::export]]
 NumericVector str_metrics(CharacterVector x, std::string fontname = "sans",
                           double fontsize = 12, int bold = false,
-                          int italic = false) {
+                          int italic = false, std::string fontfile = "") {
 
   CairoContext cc;
-  cc.setFont(fontname, fontsize, bold, italic);
+  cc.setFont(fontname, fontsize, bold, italic, fontfile);
 
   std::string str(Rf_translateCharUTF8(x[0]));
 

--- a/src/font_metrics.cpp
+++ b/src/font_metrics.cpp
@@ -14,6 +14,7 @@ using namespace Rcpp;
 //' @param bold,italic Is text bold/italic?
 //' @param fontname Font name
 //' @param fontsize Font size
+//' @param fontfile Font file
 //' @examples
 //' str_extents(letters)
 //' str_extents("Hello World!", bold = TRUE, italic = FALSE,
@@ -22,10 +23,10 @@ using namespace Rcpp;
 // [[Rcpp::export]]
 NumericMatrix str_extents(CharacterVector x, std::string fontname = "sans",
                           double fontsize = 12, int bold = false,
-                          int italic = false) {
+                          int italic = false, std::string fontfile = "") {
   int n = x.size();
   CairoContext cc;
-  cc.setFont(fontname, fontsize, bold, italic);
+  cc.setFont(fontname, fontsize, bold, italic, fontfile);
   NumericMatrix out(n, 2);
 
   for (int i = 0; i < n; ++i) {

--- a/src/gdtools.cpp
+++ b/src/gdtools.cpp
@@ -11,8 +11,9 @@ XPtrCairoContext context_create() {
 
 // [[Rcpp::export]]
 bool context_set_font(XPtrCairoContext cc, std::string fontname,
-                      double fontsize, bool bold, bool italic) {
-  cc->setFont(fontname, fontsize, bold, italic);
+                      double fontsize, bool bold, bool italic,
+                      std::string fontfile) {
+  cc->setFont(fontname, fontsize, bold, italic, fontfile);
 
   // should return void, but doesn't seem to be supported for cpp
   // interface

--- a/src/gdtools.cpp
+++ b/src/gdtools.cpp
@@ -12,7 +12,7 @@ XPtrCairoContext context_create() {
 // [[Rcpp::export]]
 bool context_set_font(XPtrCairoContext cc, std::string fontname,
                       double fontsize, bool bold, bool italic,
-                      std::string fontfile) {
+                      std::string fontfile = "") {
   cc->setFont(fontname, fontsize, bold, italic, fontfile);
 
   // should return void, but doesn't seem to be supported for cpp


### PR DESCRIPTION
Hi David,

Here is a possible other approach to handle fonts. It's a simpler modification of CairoContext. The classes from your recent patches did not seem adequate for svglite because we need to handle extra arbitrary fonts in addition to R aliased fonts. In the end, I think we just need gdtools to take an additional argument `fontfile`. Also this stores the instantiated freetype and cairo fonts in std containers since there could be any number of them.

Should this incorporate the new metrics method from your recent patches? The original method seems to be working, but I guess the new method is needed for more complicated fonts?