### PR TITLE
Don't call fcfini()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: gdtools
-Version: 0.1.1
+Version: 0.1.2
 License: GPL-3 | file LICENSE
 Title: Utilities for Graphical Rendering
 Description: Useful tools for writing vector graphics devices.

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+# gdtools 0.1.2
+
+* Fix a crash on some Linux platforms (hadley/svglite#80)
+
 # gdtools 0.1.1
 
 ## updates

--- a/src/CairoContext.cpp
+++ b/src/CairoContext.cpp
@@ -32,8 +32,6 @@ CairoContext::CairoContext() {
 }
 
 CairoContext::~CairoContext() {
-  FcFini();
-
   fontCache::iterator it = cairo_->fonts.begin();
   while (it != cairo_->fonts.end()) {
     cairo_font_face_destroy(it->second);

--- a/src/sys_fonts.cpp
+++ b/src/sys_fonts.cpp
@@ -150,7 +150,6 @@ std::string match_family_(std::string font = "sans",
   if (match && FcPatternGetString(match, FC_FAMILY, 0, &matched_family) == FcResultMatch)
     output = (const char*) matched_family;
   FcPatternDestroy(match);
-  FcFini();
 
   if (output.size())
     return output;
@@ -179,7 +178,6 @@ Rcpp::CharacterVector match_font_(std::string font = "sans",
     FcPatternGetInteger(match, FC_INDEX, 0, &index);
   }
   FcPatternDestroy(match);
-  FcFini();
 
   if (file.size()) {
     Rcpp::CharacterVector output(file);

--- a/tests/testthat/test-font_family_exists.R
+++ b/tests/testthat/test-font_family_exists.R
@@ -13,3 +13,10 @@ test_that("an valid fontname does has a match", {
   }
 })
 
+test_that("no crash after loading Fontconfig via Cairo devices", {
+  grDevices::svg(tempfile())
+  graphics::plot(1:10)
+  grDevices::dev.off()
+
+  expect_error(match_family("sans"), NA)
+})

--- a/tests/testthat/test-str_extents.R
+++ b/tests/testthat/test-str_extents.R
@@ -18,7 +18,7 @@ test_that("known fonts have correct metrics", {
 })
 
 test_that("fractional font sizes are correctly measured", {
-  if (version_freetype() < "2.6.3") {
+  if (version_freetype() < "2.6.0") {
     skip("Old FreeType return different extents for fractional sizes")
   }
   expect_equal(extents(sans, fontsize = 15.05), c(42.5317, 11.0156))


### PR DESCRIPTION
Hi David,

Unfortunately the last CRAN release of gdtools triggers a crash on some platform :/
See https://github.com/hadley/svglite/issues/80 and https://groups.google.com/forum/#!topic/shiny-discuss/5kuGWnEb_LE

This patch should fix it.