### PR TITLE
Add Import to methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,13 @@ Depends: R (>= 4.0.0)
 Imports:
     Rcpp (>= 0.12.12),
     systemfonts (>= 0.1.1),
-    htmltools, memoise, methods,
+    htmltools, memoise,
     gfonts, tools,
     curl,
     fontquiver (>= 0.2.0)
 Suggests:
-    testthat
+    testthat,
+    methods
 Encoding: UTF-8
 LinkingTo: Rcpp
 SystemRequirements: cairo, freetype2, fontconfig

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Depends: R (>= 4.0.0)
 Imports:
     Rcpp (>= 0.12.12),
     systemfonts (>= 0.1.1),
-    htmltools, memoise,
+    htmltools, memoise, methods,
     gfonts, tools,
     curl,
     fontquiver (>= 0.2.0)


### PR DESCRIPTION
As introduced here:

https://github.com/davidgohel/gdtools/blob/d0db48a336df6be73511f48e8d1ceff0a6890b3e/R/RcppExports.R#L67

I'm not 100% certain the rules around build-time dependencies on default packages, but nevertheless it seems like a good idea to include it.